### PR TITLE
updating the engilsh link

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The game is available directly from Visual Studio Code sidebar and the extension
 There is the possibility to adjust manually the height of the container in which the Wordle game is displayed.
 
 ## Supported Wordle Games
-- [The English original](https://www.powerlanguage.co.uk/wordle/) 
+- [The English original](https://www.nytimes.com/games/wordle/) 
 - [German](https://wordle.at)
 - [French](https://wordle.louan.me)
 - [Polish](https://literalnie.fun)

--- a/src/pick_language.ts
+++ b/src/pick_language.ts
@@ -7,7 +7,7 @@ type wordleType = {
 };
 
 export const wordles: wordleType = {
-    "English": "https://www.powerlanguage.co.uk/wordle/",
+    "English": "https://www.nytimes.com/games/wordle/",
     "German": "https://wordle.at",
     "French": "https://wordle.louan.me",
     "Polish": "https://literalnie.fun",


### PR DESCRIPTION
After NYTimes bought Wordle, I noticed the English link doesn't work.